### PR TITLE
fixed role_diff_rate logic

### DIFF
--- a/app/engins/game_engin.rb
+++ b/app/engins/game_engin.rb
@@ -47,8 +47,7 @@ class GameEngin
     # random deal
     players = Player.find_all
     (1..1000).each do |i|
-      random_seed = (Time.now.to_f*1000).to_i
-      role.shuffle!(:random => Random.new(random_seed))
+      role.shuffle!
       break if Player.roles_diff_rate(players, role) >= 0.8
     end
 

--- a/app/engins/game_engin.rb
+++ b/app/engins/game_engin.rb
@@ -47,7 +47,8 @@ class GameEngin
     # random deal
     players = Player.find_all
     (1..1000).each do |i|
-      role.shuffle!(:random => Random.new(Time.now.to_i))
+      random_seed = (Time.now.to_f*1000).to_i
+      role.shuffle!(:random => Random.new(random_seed))
       break if Player.roles_diff_rate(players, role) >= 0.6
     end
 

--- a/app/engins/game_engin.rb
+++ b/app/engins/game_engin.rb
@@ -49,7 +49,7 @@ class GameEngin
     (1..1000).each do |i|
       random_seed = (Time.now.to_f*1000).to_i
       role.shuffle!(:random => Random.new(random_seed))
-      break if Player.roles_diff_rate(players, role) >= 0.6
+      break if Player.roles_diff_rate(players, role) >= 0.8
     end
 
     # cache

--- a/app/engins/game_engin.rb
+++ b/app/engins/game_engin.rb
@@ -48,7 +48,7 @@ class GameEngin
     players = Player.find_all
     (1..1000).each do |i|
       role.shuffle!(:random => Random.new(Time.now.to_i))
-      break if Player.roles_diff_rate(players, role) >= 0.8
+      break if Player.roles_diff_rate(players, role) >= 0.6
     end
 
     # cache

--- a/app/engins/player.rb
+++ b/app/engins/player.rb
@@ -89,15 +89,16 @@ class Player < CacheRecord
     players_msg
   end
 
-  def self.roles_diff_rate(players, new_role)
+  def self.roles_diff_rate(players, new_roles)
     return 1.0 if !players || players.empty?
-    return 1.0 if !new_role || new_role.empty?
+    return 1.0 if !new_roles || new_roles.empty?
 
     diff_cnt = 0
     sum = 0
     players.each do |p|
       sum += 1
-      diff_cnt += 1 unless p.role && p.role.name == new_role[p.pos-1]
+      new_role = Role.init_by_role new_roles[p.pos-1]
+      diff_cnt += 1 unless p.role && p.role.side == new_role.side
     end
     diff_cnt*1.0/sum
   end

--- a/app/engins/player.rb
+++ b/app/engins/player.rb
@@ -89,16 +89,15 @@ class Player < CacheRecord
     players_msg
   end
 
-  def self.roles_diff_rate(players, new_roles)
+  def self.roles_diff_rate(players, new_role)
     return 1.0 if !players || players.empty?
-    return 1.0 if !new_roles || new_roles.empty?
+    return 1.0 if !new_role || new_role.empty?
 
     diff_cnt = 0
     sum = 0
     players.each do |p|
       sum += 1
-      new_role = Role.init_by_role new_roles[p.pos-1]
-      diff_cnt += 1 unless p.role && p.role.side == new_role.side
+      diff_cnt += 1 unless p.role && p.role.name == new_role[p.pos-1]
     end
     diff_cnt*1.0/sum
   end


### PR DESCRIPTION
Background： https://github.com/goshan/werewolf/pull/1#issuecomment-453997515

修改为millisecond的timestamp作为随机种子
问题并没有改善

```shell
irb(main):003:0> foo=%w[1 2 3 4]; (1..4).each{p foo.shuffle(:random => Random.new((Time.now.to_f*1000).to_i))}
["2", "3", "1", "4"]
["2", "3", "1", "4"]
["2", "3", "1", "4"]
["2", "3", "1", "4"]
=> 1..4
```

ruby2.0以后每次启动的random seed能够动态变化。因此使用默认的seed就可以完成。

```shell
$ ruby -e 'p Random.new.seed'                                                                                                           236078894942175743450853074266778753262
$ ruby -e 'p Random.new.seed'                                                                                                           177893364847856167474847615177711609938

$ ruby -e 'foo=%w[1 2 3 4]; (1..4).each{p foo.shuffle}'                                                                                 ["2", "4", "3", "1"]
["1", "3", "4", "2"]
["2", "1", "3", "4"]
["4", "3", "2", "1"]
$ ruby -e 'foo=%w[1 2 3 4]; (1..4).each{p foo.shuffle}'                                                                                 ["3", "1", "2", "4"]
["1", "4", "2", "3"]
["3", "4", "2", "1"]
["1", "2", "4", "3"]
```
